### PR TITLE
Fixed play time game card position

### DIFF
--- a/game/app/scenes/game_card.tscn
+++ b/game/app/scenes/game_card.tscn
@@ -89,14 +89,17 @@ margin_left = 74.0
 margin_right = 296.0
 margin_bottom = 64.0
 size_flags_horizontal = 3
+custom_constants/separation = 6
+alignment = 1
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
 [node name="LabelTitle" type="Label" parent="Card/TitleSection/VC"]
+margin_top = 10.0
 margin_right = 222.0
-margin_bottom = 40.0
-size_flags_vertical = 3
+margin_bottom = 29.0
+size_flags_vertical = 1
 custom_fonts/font = SubResource( 1 )
 text = "<game title>"
 valign = 1
@@ -105,9 +108,9 @@ __meta__ = {
 }
 
 [node name="HC" type="HBoxContainer" parent="Card/TitleSection/VC"]
-margin_top = 45.0
+margin_top = 35.0
 margin_right = 222.0
-margin_bottom = 64.0
+margin_bottom = 54.0
 custom_constants/separation = 4
 __meta__ = {
 "_edit_use_anchors_": false
@@ -222,19 +225,21 @@ margin_left = 74.0
 margin_right = 277.0
 margin_bottom = 64.0
 size_flags_horizontal = 3
+alignment = 1
 
 [node name="LabelTitle" type="Label" parent="PopupDialogInfo/VC/TitleSection/HC/Title"]
+margin_top = 10.0
 margin_right = 203.0
-margin_bottom = 40.0
-size_flags_vertical = 3
+margin_bottom = 29.0
+size_flags_vertical = 1
 custom_fonts/font = SubResource( 10 )
 text = "<game title>"
 valign = 1
 
 [node name="HC" type="HBoxContainer" parent="PopupDialogInfo/VC/TitleSection/HC/Title"]
-margin_top = 45.0
+margin_top = 34.0
 margin_right = 203.0
-margin_bottom = 64.0
+margin_bottom = 53.0
 custom_constants/separation = 4
 
 [node name="Label" type="Label" parent="PopupDialogInfo/VC/TitleSection/HC/Title/HC"]
@@ -354,6 +359,7 @@ margin_right = 388.0
 margin_bottom = 213.0
 size_flags_horizontal = 3
 size_flags_stretch_ratio = 2.0
+custom_constants/line_separation = 3
 bbcode_enabled = true
 
 [node name="VSeparator" type="VSeparator" parent="PopupDialogInfo/VC/InfoSection/HC"]

--- a/game/app/scenes/menu.tscn
+++ b/game/app/scenes/menu.tscn
@@ -195,7 +195,7 @@ title_font = ExtResource( 4 )
 
 [node name="MC" type="MarginContainer" parent="TabContainer/About"]
 margin_right = 1024.0
-margin_bottom = 829.0
+margin_bottom = 858.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 
@@ -203,15 +203,15 @@ size_flags_vertical = 3
 margin_left = 15.0
 margin_top = 15.0
 margin_right = 1009.0
-margin_bottom = 814.0
+margin_bottom = 843.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
+custom_constants/line_separation = 4
 bbcode_enabled = true
 text = "T_ABOUT_SUFFRAGIUM
 
 T_ABOUT_SUFFRAGIUM_1
 T_ABOUT_SUFFRAGIUM_2
-
 
 
 T_PARTICIPATE
@@ -232,7 +232,6 @@ T_PARTICIPATE_POSSIBILITIES_4
 T_PARTICIPATE_GUIDES
 Contributing to Suffragium
 How to add a game
-
 
 
 T_REPORT_A_BUG

--- a/game/project.godot
+++ b/game/project.godot
@@ -24,7 +24,7 @@ _global_script_classes=[ {
 "language": "GDScript",
 "path": "res://games/sortit/player.gd"
 }, {
-"base": "Reference",
+"base": "MarginContainer",
 "class": "SortItRoot",
 "language": "GDScript",
 "path": "res://games/sortit/sort_it.gd"


### PR DESCRIPTION
It now looks like this:
![grafik](https://user-images.githubusercontent.com/34373974/177007397-87569f71-f0eb-428e-9aec-fb124fcf7979.png)
And this:
![grafik](https://user-images.githubusercontent.com/34373974/177007446-8426fd60-402c-4bd3-85d3-215e180dc519.png)
As you can see the position of the playtime text has been moved up, as it looks better this way (And is also how it used to be)


This also **tries** to somewhat improve the line spacing in the about section.